### PR TITLE
Add form handler logic to addon

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -1,0 +1,59 @@
+{{#
+    @name Form handler
+    @desc Alpine based form handler used in `resources/views/page_builder/_form.antlers.html`.
+#}}
+
+<!-- statamic-peak-tools::snippets/_form_handler.antlers.html -->
+{{ once }}
+    {{# The form script handling validation and submission via AJAX with `fetch()`. #}}
+    <script>
+        document.addEventListener('alpine:initializing', () => {
+            Alpine.data('formHandler', () => {
+                return {
+                    error: false,
+                    errors: [],
+                    sending: false,
+                    success: false,
+                    sendForm: async function() {
+                        this.sending = true
+
+                        // Post the form.
+                        fetch(this.$refs.form.action, {
+                            headers: {
+                                'X-Requested-With' : 'XMLHttpRequest',
+                                'X-CSRF-Token' : await getToken()
+                            },
+                            method: 'POST',
+                            body: new FormData(this.$refs.form)})
+                        .then(res => res.json())
+                        .then(json => {
+                            if (json['success']) {
+                                this.errors = []
+                                this.success = true
+                                this.error = false
+                                this.sending = false
+                                this.$refs.form.reset()
+
+                                setTimeout(function(){
+                                    this.success = false
+                                }, 4500)
+                            }
+                            if (json['error']) {
+                                this.sending = false
+                                this.error = true
+                                this.success = false
+                                this.errors = json['error']
+                            }
+                        })
+                        .catch(err => {
+                            err.text().then( errorMessage => {
+                                this.sending = false
+                            })
+                        })
+                    }
+                }
+            })
+        })
+    </script>
+{{ /once }}
+<!-- End: statamic-peak-tools::snippets/_form_handler.antlers.html -->


### PR DESCRIPTION
Moves the Alpine based form handler to this addon. Update your site according to [this PR](https://github.com/studio1902/statamic-peak/pull/306) to use this feature.
