### PR TITLE
Load picture `srcset` from partial

### DIFF
--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -5,7 +5,7 @@
     @param* sizes The sizes attribute. Something like `(min-width: 768px) 55vw, 90vw` for example.
     @param aspect_ratio Pass in an aspect ratio to crop the image in a certain way. `16/9` for example or specify a second ratio for larger screens: `1/1 large:1/2`.
     @param skip_ratio_steps Integer. Skip 1, 2 or 3 ratio steps to force small screens rendering big images to use mobile cropping instead of `large` cropping.
-    @param srcset The path to a partial with an alternative srcsets variable array. Something like `snippets/picture/srcsets/full_width` for example.
+    @param srcset_from The path to a partial with an alternative srcset variable array. Something like `snippets/srcset_full_width` for example.
     @param class Add optional CSS classes.
     @param cover Boolean. Whether the image should cover the parent. Uses the focus position.
     @param bg String. Sets a background color for transparent images.
@@ -37,10 +37,10 @@
         {{ original_ratio = height / width }}
 
         {{# Initialize srcset variable in current scope. #}}
-        {{ srcsets = null }}
+        {{ srcset = null }}
 
         {{# Set srcset sizes. #}}
-        {{ partial src="{ srcset ?: 'statamic-peak-tools::snippets/picture/srcsets/default' }" }}
+        {{ partial src="{ srcset_from ?: 'statamic-peak-tools::snippets/srcset_default' }" }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}
@@ -62,7 +62,7 @@
             {{ else }}
                 <source
                     srcset="
-                        {{ srcsets scope="size" }}
+                        {{ srcset scope="size" }}
                             {{
                                 glide:image
                                 width="{ size:width }"
@@ -79,14 +79,14 @@
                                 format="webp"
                                 quality="{ quality ?? '85' }"
                             }} {{ size:width }}w{{ !last ?= ',' }}
-                        {{ /srcsets }}
+                        {{ /srcset }}
                     "
                     sizes="{{ sizes ?? '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw' }}"
                     type="image/webp"
                 >
                 <source
                     srcset="
-                        {{ srcsets scope="size" }}
+                        {{ srcset scope="size" }}
                             {{
                                 glide:image
                                 width="{ size:width }"
@@ -103,7 +103,7 @@
                                 quality="{ quality ?? '85' }"
                             }}
                             {{ size:width }}w{{ !last ?= ',' }}
-                        {{ /srcsets }}
+                        {{ /srcset }}
                     "
                     sizes="{{ sizes ?? '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw' }}"
                     type="{{ image.mime_type }}"

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -36,22 +36,11 @@
         {{ /aspect_ratio }}
         {{ original_ratio = height / width }}
 
-        {{# Set srcset sizes. #}}
-        {{ srcsets = [
-            [ 'width' => 320, 'ratio' => '{ ratio ?? original_ratio }' ],
-            [ 'width' => 480, 'ratio' => '{ ratio ?? original_ratio }' ],
-            [ 'width' => 640, 'ratio' => '{ ratio ?? original_ratio }' ],
-            [ 'width' => 768, 'ratio' => '{ ratio ?? original_ratio }' ],
-            [ 'width' => 1024, 'ratio' => '{ ((skip_ratio_steps != 1 && skip_ratio_steps != 2 && skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
-            [ 'width' => 1280, 'ratio' => '{ ((skip_ratio_steps != 2 && skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
-            [ 'width' => 1440, 'ratio' => '{ ((skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
-            [ 'width' => 1536, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ],
-            [ 'width' => 1680, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ]
-        ] }}
+        {{# Initialize srcset variable in current scope. #}}
+        {{ srcsets = null }}
 
-        {{ if srcset }}
-            {{ partial:if_exists :src="srcset" }}
-        {{ /if }}
+        {{# Set srcset sizes. #}}
+        {{ partial src="{ srcset ?: 'snippets/picture/srcsets/default' }" }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -40,7 +40,7 @@
         {{ srcsets = null }}
 
         {{# Set srcset sizes. #}}
-        {{ partial src="{ srcset ?: 'snippets/picture/srcsets/default' }" }}
+        {{ partial src="{ srcset ?: 'peak-tools::snippets/picture/srcsets/default' }" }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -5,7 +5,7 @@
     @param* sizes The sizes attribute. Something like `(min-width: 768px) 55vw, 90vw` for example.
     @param aspect_ratio Pass in an aspect ratio to crop the image in a certain way. `16/9` for example or specify a second ratio for larger screens: `1/1 large:1/2`.
     @param skip_ratio_steps Integer. Skip 1, 2 or 3 ratio steps to force small screens rendering big images to use mobile cropping instead of `large` cropping.
-    @param srcset_from The path to a partial with an alternative srcset variable array. Something like `snippets/srcset_full_width` for example.
+    @param srcset_from The path to a partial with an alternative srcset definition array. Something like `snippets/srcset_full_width` for example.
     @param class Add optional CSS classes.
     @param cover Boolean. Whether the image should cover the parent. Uses the focus position.
     @param bg String. Sets a background color for transparent images.
@@ -36,7 +36,7 @@
         {{ /aspect_ratio }}
         {{ original_ratio = height / width }}
 
-        {{# Initialize srcset variable in current scope. #}}
+        {{# Initialize srcset variable in current scope to be overwritable from partial below. #}}
         {{ srcset = null }}
 
         {{# Set srcset sizes. #}}

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -40,7 +40,7 @@
         {{ srcsets = null }}
 
         {{# Set srcset sizes. #}}
-        {{ partial src="{ srcset ?: 'peak-tools::snippets/picture/srcsets/default' }" }}
+        {{ partial src="{ srcset ?: 'statamic-peak-tools::snippets/picture/srcsets/default' }" }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -5,6 +5,7 @@
     @param* sizes The sizes attribute. Something like `(min-width: 768px) 55vw, 90vw` for example.
     @param aspect_ratio Pass in an aspect ratio to crop the image in a certain way. `16/9` for example or specify a second ratio for larger screens: `1/1 large:1/2`.
     @param skip_ratio_steps Integer. Skip 1, 2 or 3 ratio steps to force small screens rendering big images to use mobile cropping instead of `large` cropping.
+    @param srcset The path to a partial with an alternative srcsets variable array. Something like `snippets/picture/srcsets/full_width` for example.
     @param class Add optional CSS classes.
     @param cover Boolean. Whether the image should cover the parent. Uses the focus position.
     @param bg String. Sets a background color for transparent images.
@@ -47,6 +48,10 @@
             [ 'width' => 1536, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ],
             [ 'width' => 1680, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ]
         ] }}
+
+        {{ if srcset }}
+            {{ partial:if_exists :src="srcset" }}
+        {{ /if }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}

--- a/resources/views/snippets/_srcset_default.antlers.html
+++ b/resources/views/snippets/_srcset_default.antlers.html
@@ -1,3 +1,8 @@
+{{#
+    @name Default `scrset` definition
+    @desc The default definition for the `srcset` attribute which gets loaded in `statamic-peak-tools::components/_picture.antlers.html`.
+#}}
+
 {{ srcset = [
     [ 'width' => 320, 'ratio' => '{ ratio ?? original_ratio }' ],
     [ 'width' => 480, 'ratio' => '{ ratio ?? original_ratio }' ],

--- a/resources/views/snippets/_srcset_default.antlers.html
+++ b/resources/views/snippets/_srcset_default.antlers.html
@@ -1,4 +1,4 @@
-{{ srcsets = [
+{{ srcset = [
     [ 'width' => 320, 'ratio' => '{ ratio ?? original_ratio }' ],
     [ 'width' => 480, 'ratio' => '{ ratio ?? original_ratio }' ],
     [ 'width' => 640, 'ratio' => '{ ratio ?? original_ratio }' ],

--- a/resources/views/snippets/picture/srcsets/_default.antlers.html
+++ b/resources/views/snippets/picture/srcsets/_default.antlers.html
@@ -1,0 +1,11 @@
+{{ srcsets = [
+    [ 'width' => 320, 'ratio' => '{ ratio ?? original_ratio }' ],
+    [ 'width' => 480, 'ratio' => '{ ratio ?? original_ratio }' ],
+    [ 'width' => 640, 'ratio' => '{ ratio ?? original_ratio }' ],
+    [ 'width' => 768, 'ratio' => '{ ratio ?? original_ratio }' ],
+    [ 'width' => 1024, 'ratio' => '{ ((skip_ratio_steps != 1 && skip_ratio_steps != 2 && skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
+    [ 'width' => 1280, 'ratio' => '{ ((skip_ratio_steps != 2 && skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
+    [ 'width' => 1440, 'ratio' => '{ ((skip_ratio_steps != 3) ?= ratio_large) ?? ratio ?? original_ratio }' ],
+    [ 'width' => 1536, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ],
+    [ 'width' => 1680, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ]
+] }}


### PR DESCRIPTION
Sometimes the default picture `srcset` definition is not ideal for a specific case or the whole project. At the moment the only solution would be to alter the picture partial by publishing it but this cuts it off from future updates in the addon.

I was wondering if it wouldn't be nice to override the default definition by publishing just the default definition, or to pass a different definition for a specific case.

Due to when / how Antlers evaluates the variables the definition has to be in a partial.

```antlers
{{# Uses the default definition (no changes) #}}
{{ partial:statamic-peak-tools::components/picture ... }}

{{# Uses a custom definition by passing a path #}}
{{ partial:statamic-peak-tools::components/picture ...  srcset_from="path/to/definition" }}
```

```antlers
{{# the definition in `path/to/definition` #}}
{{ srcset = [
   ... 
  [ 'width' => 3840, 'ratio' => '{ ratio_large ?? ratio ?? original_ratio }' ],
] }}
```

Changes proposed in this pull request:
- Extract the default `srcset` definition to a dedicated partial
- Adds the ability to pass a path to a partial which holds an alternative definition for the `srcset` variable
