### PR TITLE
Fix context for `this.success` in form handler

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -36,7 +36,7 @@
                                 this.sending = false
                                 this.$refs.form.reset()
 
-                                setTimeout(function(){
+                                setTimeout(() => {
                                     this.success = false
                                 }, 4500)
                             }


### PR DESCRIPTION
Fixes #5  .

Changes proposed in this pull request:
- Ensure that `this.success` refers to the alpine component context by using an arrow function in the form handler.
