### PR TITLE
Allow token refreshing from any host while in local environment

### DIFF
--- a/src/Http/Controllers/DynamicToken.php
+++ b/src/Http/Controllers/DynamicToken.php
@@ -7,21 +7,32 @@ use Illuminate\Http\Request;
 
 class DynamicToken extends Controller
 {
-     /**
+    /**
      * Get refreshed CSRF token.
      *
      * @return string
      */
     public function __invoke(Request $request)
     {
-        $referer = request()->headers->get('referer');
-        $contains = str_contains($referer, request()->getHttpHost());
-        if (empty($referer) || !$contains) {
+        if (!$this->isSafeRequest()) {
             abort(404);
         }
 
         return response()->json([
             'csrf_token' => csrf_token()
         ]);
+    }
+
+    protected function isSafeRequest(): bool
+    {
+        if (!($referer = request()->headers->get('referer'))) {
+            return false;
+        }
+
+        if (in_array(config('app.env'), ['local'])) {
+            return true;
+        }
+
+        return str_contains($referer, request()->getHttpHost());
     }
 }


### PR DESCRIPTION
When submitting frontend forms with Browsersync via IP proxy (`http://192.168.8.12:3000` instead of `http://myinstallation.test`) the csrf token can not be refreshed because the IP does not match with the `request()->getHttpHost()` and the request gets rejected.

I propose to allow any referer to refresh the token as long as the `app.env` is set to `local`.

Changes proposed in this pull request:
Allow token refreshing from any host while in local environment
