### PR TITLE
Implement a beter caching solution

### DIFF
--- a/resources/views/widgets/images-missing-alt.blade.php
+++ b/resources/views/widgets/images-missing-alt.blade.php
@@ -5,7 +5,7 @@
                 <div class="h-6 w-6 mr-2 text-gray-800">
                     @cp_svg('icons/light/assets')
                 </div>
-                <span>{{ __('strings.widget_assets_title', ['container' => $container]) }}</span>
+                <span>{{ __('strings.widget_assets_title', ['container' => $containers[0]]) }}</span>
             </div>
         </h2>
     </div>

--- a/src/Jobs/UpdateMissingAltCacheJob.php
+++ b/src/Jobs/UpdateMissingAltCacheJob.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Studio1902\PeakTools\Widgets\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\SerializesModels;
+use Statamic\Assets\Asset;
+
+class UpdateMissingAltCacheJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public $tries = 2;
+
+    protected $event;
+
+    /**
+     * @return void
+     */
+    public function __construct($event)
+    {
+        $this->event = $event;
+    }
+
+    public function handle(\Studio1902\PeakTools\Widgets\Services\Service $service)
+    {
+        $service->clearCache($this->getAssetContainerHandle());
+        $service->preloadCache($this->getAssetContainerHandle());
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware()
+    {
+        return [(new WithoutOverlapping($this->getAssetContainerHandle()))->releaseAfter(60)->expireAfter(180)];
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return $this->getAssetContainerHandle();
+    }
+
+    private function getAssetContainerHandle(): string
+    {
+        /** @var Asset $asset */
+        $asset = $this->event->asset;
+
+        return $asset->container()->handle();
+    }
+}

--- a/src/Jobs/UpdateMissingAltCacheJob.php
+++ b/src/Jobs/UpdateMissingAltCacheJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\PeakTools\Widgets\Jobs;
+namespace Studio1902\PeakTools\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
@@ -30,7 +30,7 @@ class UpdateMissingAltCacheJob implements ShouldQueue, ShouldBeUniqueUntilProces
         $this->event = $event;
     }
 
-    public function handle(\Studio1902\PeakTools\Widgets\Services\Service $service)
+    public function handle(\Studio1902\PeakTools\Services\Service $service)
     {
         $service->clearCache($this->getAssetContainerHandle());
         $service->preloadCache($this->getAssetContainerHandle());

--- a/src/Listeners/UpdateImagesMissingAltCacheListener.php
+++ b/src/Listeners/UpdateImagesMissingAltCacheListener.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Studio1902\PeakTools\Widgets\Listeners;
+namespace Studio1902\PeakTools\Listeners;
 
 use Statamic\Events\AssetDeleted;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
-use Studio1902\PeakTools\Widgets\Jobs\UpdateMissingAltCacheJob;
+use Studio1902\PeakTools\Jobs\UpdateMissingAltCacheJob;
 
 class UpdateImagesMissingAltCacheListener
 {

--- a/src/Listeners/UpdateImagesMissingAltCacheListener.php
+++ b/src/Listeners/UpdateImagesMissingAltCacheListener.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Studio1902\PeakTools\Widgets\Listeners;
+
+use Statamic\Events\AssetDeleted;
+use Statamic\Events\AssetSaved;
+use Statamic\Events\AssetUploaded;
+use Studio1902\PeakTools\Widgets\Jobs\UpdateMissingAltCacheJob;
+
+class UpdateImagesMissingAltCacheListener
+{
+    public function handle($event)
+    {
+        UpdateMissingAltCacheJob::dispatch($event);
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param \Illuminate\Events\Dispatcher $events
+     * @return void
+     */
+    public function subscribe($events)
+    {
+        $events->listen(AssetDeleted::class, [self::class, 'handle']);
+        $events->listen(AssetSaved::class, [self::class, 'handle']);
+        $events->listen(AssetUploaded::class, [self::class, 'handle']);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,7 @@ namespace Studio1902\PeakTools;
 
 use Statamic\Providers\AddonServiceProvider;
 use Studio1902\PeakTools\Widgets\ImagesMissingAlt;
-use Studio1902\PeakTools\Widgets\Listeners\UpdateImagesMissingAltCacheListener;
+use Studio1902\PeakTools\Listeners\UpdateImagesMissingAltCacheListener;
 
 class ServiceProvider extends AddonServiceProvider
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,11 +4,16 @@ namespace Studio1902\PeakTools;
 
 use Statamic\Providers\AddonServiceProvider;
 use Studio1902\PeakTools\Widgets\ImagesMissingAlt;
+use Studio1902\PeakTools\Widgets\Listeners\UpdateImagesMissingAltCacheListener;
 
 class ServiceProvider extends AddonServiceProvider
 {
     protected $routes = [
         'actions' => __DIR__ . '/../routes/actions.php',
+    ];
+
+    protected $subscribe = [
+        UpdateImagesMissingAltCacheListener::class,
     ];
 
     protected $widgets = [

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Studio1902\PeakTools\Widgets\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Statamic\Facades\Asset;
+
+class Service
+{
+    public function getCacheKey(string $container): string
+    {
+        return "widgets::StatamicImagesMissingAlt.{$container}";
+    }
+
+    public function clearCache(string $container): void
+    {
+        Cache::forget($this->getCacheKey($container));
+    }
+
+    public function getImagesWithMissingAlt(string $container): array
+    {
+        return Cache::rememberForever(
+            $this->getCacheKey($container),
+            function () use ($container) {
+                return Asset::query()
+                    ->where('container', $container)
+                    ->where('is_image', true)
+                    ->whereNull('alt')
+                    ->orderBy('last_modified', 'desc')
+                    ->limit(100)
+                    ->get()
+                    ->toAugmentedArray();
+            },
+        );
+    }
+
+    public function preloadCache(string $container): void
+    {
+        $this->getImagesWithMissingAlt($container);
+    }
+}

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\PeakTools\Widgets\Services;
+namespace Studio1902\PeakTools\Services;
 
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Asset;

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -9,7 +9,7 @@ class Service
 {
     public function getCacheKey(string $container): string
     {
-        return "widgets::StatamicImagesMissingAlt.{$container}";
+        return "widgets::ImagesMissingAlt.{$container}";
     }
 
     public function clearCache(string $container): void

--- a/src/Widgets/ImagesMissingAlt.php
+++ b/src/Widgets/ImagesMissingAlt.php
@@ -33,7 +33,7 @@ class ImagesMissingAlt extends Widget
 
         $assets = $assets->sortByDesc('last_modified')->values();
 
-        return view('statamic-images-missing-alt::widgets.images-missing-alt', [
+        return view('statamic-peak-tools::widgets.images-missing-alt', [
             'assets' => $assets->slice(0, $this->config('limit', 5)),
             'amount' => $assets->count(),
             'containers' => $containers->map(fn (string $container) => AssetContainer::findByHandle($container)->title()),

--- a/src/Widgets/ImagesMissingAlt.php
+++ b/src/Widgets/ImagesMissingAlt.php
@@ -4,7 +4,7 @@ namespace Studio1902\PeakTools\Widgets;
 
 use Statamic\Facades\AssetContainer;
 use Statamic\Widgets\Widget;
-use Studio1902\PeakTools\Widgets\Services;
+use Studio1902\PeakTools\Services\Service;
 
 class ImagesMissingAlt extends Widget
 {


### PR DESCRIPTION
- Caches the assets without alts indefinitely.
- Re-caches them when assets are being edited, deleted or upload via listeners.
- Fetches the assets without an alt in a job that's can be queued.