### PR TITLE
Fix statamic conditionals not working

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -13,12 +13,15 @@
             Alpine.data('formHandler', () => ({
                 success: false,
                 form: '',
+                dynamic_form: null,
                 init() {
                     this.form = this.$form(
                         'post',
                         this.$refs.form.getAttribute('action'),
                         JSON.parse(this.$refs.form.getAttribute('x-data')).dynamic_form
                     )
+
+                    this.dynamic_form = this.form
                 },
                 succesHook() {
                     {{ success_hook }}


### PR DESCRIPTION
Changes proposed in this pull request:
-
This PR makes the statamic conditionals work again by adding the ``dynamic_form`` to the form handler. This might be a workaround for now, but is working with the existing logic with no further adjustments necessary.

Background: as of v4.0.0 of the peak-tools and the necessary rewrite to make Laravel Precognition work, the conditonals stopped working.

## How to test
1. Create a form that hides some fields conditionally. 
2. Test the form by changing values and see the hidden fields appear 😄 