### PR TITLE
Form submission: Log non-validation errors to console.

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -46,7 +46,13 @@
                         })
                         .then(this.$refs.form.scrollIntoView())
                         .catch(error => {
-                            this.$focus.focus(document.querySelector('#summary').querySelector('a'))
+                            const summary = document.querySelector('#summary')
+                            if (summary) {
+                                this.$focus.focus(summary.querySelector('a'))
+                            }
+                            else {
+                                console.log(error)
+                            }
                         })
                 }
             }))


### PR DESCRIPTION
If an error occurs during form submission that's not a validation error (for example, an error in the successHook script), the error is swallowed and another error occurs in console because the #summary element is not found.

This PR fixes that by checking if #summary exists before attempting to focus on it, and if not, logs the error to console instead.