### PR TITLE
Default successHook on forms

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -30,6 +30,10 @@
                 },
                 successHook(response) {
                     {{ success_hook }}
+
+                    setTimeout(() => {
+                        this.success = false
+                    }, 4500)
                 },
                 submit() {
                     this.submitted = true
@@ -40,9 +44,6 @@
                             this.success = true
                             this.submitted = false
                             this.successHook(response)
-                            setTimeout(() => {
-                                this.success = false
-                            }, 4500)
                         })
                         .then(this.$refs.form.scrollIntoView())
                         .catch(error => {


### PR DESCRIPTION
This PR moves the ``setTimeout()`` function into the ``successHook()`` method which allow for it to be overridden or skipped, depending on what you pass into the ``success_hook`` parameter of the partial.

If something is passed without a return statement, the ``setTimeout()`` will still be called, executing additional features before it. Passing something with a return statement, skips the ``setTimeout()`` completely.

Closes studio1902/statamic-peak#393

Changes proposed in this pull request:
- Moved the setTimeout() function into the successHook() method
