### PR TITLE
Add Captcha Support

### DIFF
--- a/resources/views/snippets/_form_handler.antlers.html
+++ b/resources/views/snippets/_form_handler.antlers.html
@@ -36,6 +36,10 @@
                     }, 10000)
                 },
                 submit() {
+                    if (Object.keys(this.form).includes('captcha-response')) {
+                        this.form['captcha-response'] = this.$refs.form.querySelector('{{ captcha:selector }}')?.value
+                    }
+
                     this.submitted = true
                     this.form.submit()
                         .then(response => {


### PR DESCRIPTION
As discussed in our call earlier (in response to https://github.com/aryehraber/statamic-captcha/issues/59), hereby a small addition that will check if the user has set `captcha-response` on their Statamic form and automatically handle setting the captcha's response token on the form object before submitting.

I have just released a new version of Captcha, which includes the `{{ captcha:selector }}` tag, therefore `v1.14.0` is the minimum required version to make this work.