### PR TITLE
Refactor to skip links

### DIFF
--- a/resources/views/navigation/_skip_links.antlers.html
+++ b/resources/views/navigation/_skip_links.antlers.html
@@ -1,0 +1,13 @@
+{{#
+    @name Skip to links
+    @desc The first buttons that pop up when a user tabs. This enables them to skip directly to specified areas.
+#}}
+
+<!-- statamic-peak-tools::navigation/_skip_links.antlers.html -->
+<div class="z-50 text-sm font-bold text-white [&_a]:fixed [&_a]:px-4 [&_a]:py-2 [&_a]:-translate-y-24 [&_a]:opacity-0 [&_a]:top-4 [&_a]:left-8 [&_a]:bg-primary [&_a]:focus-visible:translate-y-0 [&_a]:focus-visible:opacity-100 [&_a]:focus:outline-none [&_a]:focus-visible:ring-2 [&_a]:ring-primary [&_a]:ring-offset-2 [&_a]:motion-safe:transition-transform">
+    {{ if defaults || defaults === null }}
+        <a href="#content">{{ trans:strings.skip_to_content }}</a>
+    {{ /if }}
+    {{ slot}}
+</div>
+<!-- End: statamic-peak-tools::navigation/_skip_links.antlers.html -->

--- a/resources/views/navigation/_skip_to_content.antlers.html
+++ b/resources/views/navigation/_skip_to_content.antlers.html
@@ -4,7 +4,5 @@
 #}}
 
 <!-- statamic-peak-tools::navigation/_skip_to_content.antlers.html -->
-<a class="fixed z-50 px-4 py-2 text-sm font-bold text-white -translate-y-24 opacity-0 top-4 left-8 bg-primary focus-visible:translate-y-0 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 ring-primary ring-offset-2 motion-safe:transition-transform" href="#content">
-    {{ trans:strings.skip_to_content }}
-</a>
+{{ partial:statamic-peak-tools::navigation/skip_links }}
 <!-- End: statamic-peak-tools::navigation/_skip_to_content.antlers.html -->


### PR DESCRIPTION
As discussed with Rob, this PR adds the ability to add multiple skip links if necessary. The ``skip_to_content`` partial is now including the newly created ``skip_links`` partial. This will ensure backwards compatibility with current installs that didn't publish the view while published views remain untouched and functional as well.

So here's a shameless copy of the docs PR:

If you need to, you can add additional skip links via the slot of the view or disable the default content link by passing `defaults="false"`.

```handlebars
{{ partial:statamic-peak-tools::navigation/skip_links defaults="false" }}
    <a href="#search">Search</a>
    <a href="#contact">Contact</a>
{{ /partial:statamic-peak-tools::navigation/skip_links }}
```