### PR TITLE
Extract default picture formats into a config file

### DIFF
--- a/config/statamic-peak-tools.php
+++ b/config/statamic-peak-tools.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'picture' => [
+        'default_formats' => [
+            'avif' => 'image/avif',
+            'webp' => 'image/webp',
+            'jpg' => 'image/jpeg',
+        ]
+    ]
+];

--- a/resources/views/components/_picture.antlers.html
+++ b/resources/views/components/_picture.antlers.html
@@ -45,7 +45,7 @@
         {{ partial src="{ srcset_from ?: 'statamic-peak-tools::snippets/srcset_default' }" }}
 
         {{# Image formats. #}}
-        {{ formats = formats ?? ['avif' => 'image/avif', 'webp' => 'image/webp', 'jpg' => 'image/jpeg'] }}
+        {{ formats = formats ?? {config:statamic-peak-tools:picture:default_formats} }}
 
         <picture>
             {{ if extension == 'svg' || extension == 'gif' }}


### PR DESCRIPTION
Fixes #27

Changes proposed in this pull request:
- Extract the default picture formats into a config file
