### PR TITLE
Cache the scalar values of an asset

### DIFF
--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -30,7 +30,12 @@ class Service
                     ->orderBy('last_modified', 'desc')
                     ->limit(100)
                     ->get()
-                    ->toAugmentedArray();
+                    ->map(fn ($asset) => [
+                        'edit_url' => $asset->editUrl(),
+                        'basename' => $asset->basename(),
+                        'last_modified' => $asset->lastModified()->timestamp,
+                    ])
+                    ->all();
             },
         );
     }


### PR DESCRIPTION
Fixes #37 .

Changes proposed in this pull request:
- Cache only the scalar values of an asset
